### PR TITLE
Fix: Configure Vite for Replit environment

### DIFF
--- a/nuxt-app-donut/nuxt.config.ts
+++ b/nuxt-app-donut/nuxt.config.ts
@@ -15,4 +15,22 @@ export default defineNuxtConfig({
     }
   },
   css: ['~/assets/main.css'], // Assuming we will create this for global styles
+  vite: {
+    server: {
+      // Configure HMR for Replit or similar environments
+      hmr: {
+        protocol: 'wss', // Use 'wss' for HTTPS, 'ws' for HTTP
+        // Dynamically set the host for HMR using Replit environment variables if available
+        // Fallback to 'localhost' if not in a Replit-like environment or vars are not set
+        host: process.env.REPL_SLUG && process.env.REPL_OWNER
+              ? `${process.env.REPL_SLUG}.${process.env.REPL_OWNER}.repl.co`
+              : 'localhost',
+        // clientPort: 443 // Usually not needed if host and protocol are correct
+      },
+      // Allow requests from any host.
+      // This is generally acceptable for development in trusted environments like Replit.
+      // Be cautious if deploying to a more open or production environment.
+      allowedHosts: ['*'],
+    }
+  }
 })


### PR DESCRIPTION
- Updated `nuxt.config.ts` to allow requests from all hosts (`allowedHosts: ['*']`) for Vite's dev server.
- Configured Vite's HMR (Hot Module Replacement) server to use dynamic host resolution for Replit and `wss` protocol.

This resolves the "Blocked request" error when running the Nuxt app in a Replit environment.