### PR TITLE
Fix canvas to use complete viewport height without margins

### DIFF
--- a/nuxt-app-donut/app.vue
+++ b/nuxt-app-donut/app.vue
@@ -13,21 +13,30 @@
 </script>
 
 <style>
-/* Global styles from the original style.css */
-html, body {
+/* Global styles - ensure full viewport coverage */
+* {
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
+}
+
+html, body {
+  width: 100%;
+  height: 100%;
   background-color: #000;
-  color: #00ff00; /* Green text color */
+  color: #00ff00;
   font-family: monospace;
-  overflow: hidden; /* Hide scrollbars if content overflows */
-  width: 100vw;
-  height: 100vh;
+  overflow: hidden;
+}
+
+#__nuxt, #__layout {
+  width: 100%;
+  height: 100%;
 }
 
 /* Root div should take full viewport */
 div {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/nuxt-app-donut/components/DonutDisplay.vue
+++ b/nuxt-app-donut/components/DonutDisplay.vue
@@ -223,14 +223,18 @@ onUnmounted(() => {
 
 <style scoped>
 .donut-pre-tag {
-  font-size: 10px; /* Base size, actual character grid depends on this + viewport */
-  line-height: 1; /* Crucial for consistent charHeight calculation */
-  width: 100vw;
-  height: 100vh;
-  text-align: left; /* Original was center, but per-line content forms the shape */
+  font-size: 10px;
+  line-height: 1;
+  width: 100%;
+  height: 100%;
+  text-align: left;
   white-space: pre;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 </style>


### PR DESCRIPTION
- Add global CSS reset to eliminate default margins/padding
- Set full height chain: html, body, #__nuxt, #__layout, div
- Position donut canvas absolutely to fill entire viewport
- Remove black margins at top/bottom of canvas display

🤖 Generated with [Claude Code](https://claude.ai/code)