### PR TITLE
Fix donut rendering to utilize full viewport by adjusting font sizing

### DIFF
--- a/nuxt-app-donut/components/DonutDisplay.vue
+++ b/nuxt-app-donut/components/DonutDisplay.vue
@@ -223,8 +223,8 @@ onUnmounted(() => {
 
 <style scoped>
 .donut-pre-tag {
-  font-size: 10px;
-  line-height: 1;
+  font-size: 8px;
+  line-height: 8px;
   width: 100%;
   height: 100%;
   text-align: left;


### PR DESCRIPTION
Reduced font-size from 10px to 8px and set line-height to 8px to ensure proper character grid calculations and full canvas utilization.

🤖 Generated with [Claude Code](https://claude.ai/code)